### PR TITLE
Remove unused package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get -y --no-install-recommends install \
 	openssl \
 	ca-certificates \
 	imagemagick \
-	dvipng \
 	nginx \
 	php \
 	php-fpm \


### PR DESCRIPTION
`dvi2png` is only required for `Texvc` which is not used anymore

See https://www.mediawiki.org/wiki/Texvc