### PR TITLE
Fix default port suffix

### DIFF
--- a/root-fs/app/conf/LocalSettings.php
+++ b/root-fs/app/conf/LocalSettings.php
@@ -6,7 +6,7 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 ### Dynamic assembly of $GLOBALS['wgServer']
 $protocol = getenv( 'WIKI_PROTOCOL' ) ?: 'https';
 $host = getenv( 'WIKI_HOST' ) ?: 'localhost';
-$portSuffix = getenv( 'WIKI_PORT' ) ? ':' . getenv( 'WIKI_PORT' ) : '443';
+$portSuffix = getenv( 'WIKI_PORT' ) ? ':' . getenv( 'WIKI_PORT' ) : ':443';
 if ( $protocol === 'http' && $portSuffix === ':80' ) {
 	$portSuffix = '';
 } elseif ( $protocol === 'https' && $portSuffix === ':443' ) {


### PR DESCRIPTION
We must include the `:` when using the default.