### PR TITLE
Use same default value as in `LocalSettings.php`

### DIFF
--- a/root-fs/app/bin/run-installation
+++ b/root-fs/app/bin/run-installation
@@ -28,7 +28,7 @@ php $appDir/maintenance/install.php \
 	--dbuser=$DB_USER \
 	--dbpass=$DB_PASS \
 	--pass=$adminPass \
-	--lang=$WIKI_LANG \
+	--lang=${WIKI_LANG:-en} \
 	--scriptpath=/w \
 	$WIKI_NAME \
 	Admin \


### PR DESCRIPTION
If `WIKI_LANG` is omitted installation will fail.