### PR TITLE
Remove custom CS config option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,6 @@ ADD --chown=$USER:$GROUPNAME --chmod=755 https://raw.githubusercontent.com/hallo
 ADD --chown=$USER:$GROUPNAME --chmod=755 https://github.com/hallowelt/misc-mediawiki-adm/releases/latest/download/mediawiki-adm /app/bin
 ADD --chown=$USER:$GROUPNAME --chmod=755 https://github.com/hallowelt/misc-parallel-runjobs-service/releases/latest/download/parallel-runjobs-service /app/bin
 ADD --chown=$USER:$GROUPNAME --chmod=755 https://github.com/aptible/supercronic/releases/download/v0.2.33/supercronic-linux-amd64 /app/bin/supercronic
-ADD --chmod=644 https://curl.se/ca/cacert.pem /usr/local/share/ca-certificates/ca.crt
 COPY ./root-fs/etc/php/8.x/fpm/conf.d/* /etc/php/8.4/fpm/conf.d
 COPY ./root-fs/etc/php/8.x/fpm/php-fpm.conf /etc/php/8.4/fpm/
 COPY ./root-fs/etc/php/8.x/fpm/pool.d/www.conf /etc/php/8.4/fpm/pool.d/

--- a/README.md
+++ b/README.md
@@ -98,8 +98,14 @@ The main directory for application data is `/data/`. The setup routine will crea
 └── .wikienv                     -> Automatically created during installation. Contains various keys.
 ```
 
-If the application needs to connect to external services that use self-signed certificates, you need to add the certificate to the trusted certificates.
-For this purpose, you can mount a volume to `/usr/local/share/ca-certificates/ca.crt`
+## Custom SSL certificates
+
+If the application needs to connect to external services that use self-signed certificates, make sure to add those to the `/etc/ssl/certs/ca-certificates.crt` of the **hostmachine** and then mount it into the container like this:
+
+```yaml
+volumes:
+  - /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro
+```
 
 ## Profiling
 

--- a/root-fs/etc/php/8.x/cli/conf.d/90-bluespice-overrides.ini
+++ b/root-fs/etc/php/8.x/cli/conf.d/90-bluespice-overrides.ini
@@ -17,5 +17,3 @@ display_errors=off
 display_startup_errors = Off
 error_reporting=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING & ~E_USER_NOTICE & ~E_USER_DEPRECATED & ~E_USER_WARNING
 error_log = /proc/1/fd/2
-curl.cainfo=/usr/local/share/ca-certificates/ca.crt
-openssl.cafile=/usr/local/share/ca-certificates/ca.crt

--- a/root-fs/etc/php/8.x/fpm/conf.d/90-bluespice-overrides.ini
+++ b/root-fs/etc/php/8.x/fpm/conf.d/90-bluespice-overrides.ini
@@ -17,5 +17,3 @@ display_errors=off
 display_startup_errors = Off
 error_reporting=E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED & ~E_WARNING & ~E_USER_NOTICE & ~E_USER_DEPRECATED & ~E_USER_WARNING
 error_log = /proc/1/fd/2
-curl.cainfo=/usr/local/share/ca-certificates/ca.crt
-openssl.cafile=/usr/local/share/ca-certificates/ca.crt


### PR DESCRIPTION
This causes trouble when the custom file is not mounted or empty. The better approach is to mount the regular CA file from the hostmachine into the container.