### PR TITLE
Avoid error with non-existing DBs

### DIFF
--- a/root-fs/app/bin/run-installation.d/010-init-database
+++ b/root-fs/app/bin/run-installation.d/010-init-database
@@ -18,7 +18,7 @@ echo "Initializing database '$dbName' on $dbHost ... \n";
 
 try {
 	$pdo = new PDO(
-		"mysql:host=$dbHost;dbname=$dbName",
+		"mysql:host=$dbHost",
 		$dbRootUser,
 		$dbRootPass
 	);


### PR DESCRIPTION
If the DB does not exist, we can not use it in the connection string.