### PR TITLE
Fix "rebuild searchindex" during initial installation

### DIFF
--- a/root-fs/app/bin/run-installation.d/060-build-initial-search-index
+++ b/root-fs/app/bin/run-installation.d/060-build-initial-search-index
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-rebuild-searchindex --all
+rebuild-searchindex --main


### PR DESCRIPTION
During installation there are no sub-wikis that would need their search indexes to be rebuild.