### PR TITLE
Fix issue with missing WIKI_BASE_PATH

### DIFF
--- a/root-fs/app/bin/start-web
+++ b/root-fs/app/bin/start-web
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 substitutePlaceholders /app/conf/nginx_bluespice
-if [[ -n "${WIKI_BASE_PATH}" && "${WIKI_BASE_PATH}" != "/" ]]; then
+if [[ "${WIKI_BASE_PATH:-/}" != "/" ]]; then
 	mkdir -p /app/bluespice${WIKI_BASE_PATH}
 	ln -sf /app/bluespice/w /app/bluespice${WIKI_BASE_PATH}w
 fi


### PR DESCRIPTION
If not set properly, container will fail with
```
wiki-web  | 
wiki-web  | #############################################
wiki-web  | Init data directory
wiki-web  | Done
wiki-web  | 
wiki-web  | #############################################
wiki-web  | Substitute placeholders in '/app/conf/nginx_bluespice'
wiki-web  | /app/bin/start-web: line 6: WIKI_BASE_PATH: unbound variable
```

But variable is documented as optional.