### PR TITLE
print substituted placeholders only once

### DIFF
--- a/root-fs/app/bin/substitutePlaceholders
+++ b/root-fs/app/bin/substitutePlaceholders
@@ -15,9 +15,11 @@ if (!file_exists($file)) {
 
 $contents = file_get_contents( $file );
 $pattern = '/###([A-Z_]+)(\|[^#]+)?###/';
+$printedVars= [];
+
 $modifiedContents = preg_replace_callback(
 	$pattern,
-	function( $matches ) {
+	function( $matches ) use (&$printedVars) {
 		$envVarName = $matches[1];
 		$defaultValue = $matches[2] ?? '';
 		$defaultValue = substr( $defaultValue, 1 );
@@ -27,11 +29,15 @@ $modifiedContents = preg_replace_callback(
 			$envVarValue = $defaultValue;
 		}
 
-		$outputValue = $envVarValue;
-		if ( strpos( $envVarName, 'PASS' ) !== false ) {
-			$outputValue = str_repeat( '*', strlen( $envVarValue ) );
+		if ( !in_array($envVarName, $printedVars) ) {
+			$outputValue = $envVarValue;
+			if ( strpos( $envVarName, 'PASS' ) !== false ) {
+				$outputValue = str_repeat( '*', strlen( $envVarValue ) );
+			}
+			echo "###$envVarName### -> $outputValue\n";
+			$printedVars[] = $envVarName;
 		}
-		echo "###$envVarName### -> $outputValue\n";
+
 		return $envVarValue;
 	},
 	$contents


### PR DESCRIPTION
Reduces noise by printing substituted placeholders only once.

For eg. on startup this seems too noisy, especially when printing defaults. like:

```
bluespice-wiki-web  |   ____  _            ____        _
bluespice-wiki-web  |  | __ )| |_   _  ___/ ___| _ __ (_) ___ ___
bluespice-wiki-web  |  |  _ \| | | | |/ _ \___ \| '_ \| |/ __/ _ \
bluespice-wiki-web  |  | |_) | | |_| |  __/___) | |_) | | (_|  __/
bluespice-wiki-web  |  |____/|_|\__,_|\___|____/| .__/|_|\___\___|
bluespice-wiki-web  |                           |_|
bluespice-wiki-web  | 🚀 BlueSpice pro 5.1.1
bluespice-wiki-web  | ---------------------------------------------
bluespice-wiki-web  | 
bluespice-wiki-web  | 
bluespice-wiki-web  | #############################################
bluespice-wiki-web  | Substitute placeholders in '/app/bin/config/clamd.conf'
bluespice-wiki-web  | ###AV_HOST### -> antivirus
bluespice-wiki-web  | ###AV_PORT### -> 3310
bluespice-wiki-web  | 
bluespice-wiki-web  | #############################################
bluespice-wiki-web  | Init data directory
bluespice-wiki-web  | Done
bluespice-wiki-web  | 
bluespice-wiki-web  | #############################################
bluespice-wiki-web  | Substitute placeholders in '/app/conf/nginx_bluespice'
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
bluespice-wiki-web  | ###WIKI_BASE_PATH### -> /
```