### PR TITLE
fix defaultRedirect for FARM

### DIFF
--- a/root-fs/app/conf/nginx_bluespice
+++ b/root-fs/app/conf/nginx_bluespice
@@ -98,6 +98,6 @@ server {
 	}
 
 	location = / {
-		return 301 ###WIKI_BASE_PATH|/###w;
+		return 301 ###WIKI_BASE_PATH|/###wiki;
 	}
 }


### PR DESCRIPTION
`$GLOBALS['wgWikiFarmConfig_defaultRedirect'] = '/de';` no longer works

Would it be ok to redirect to /wiki here? (If WIKI_BASE_PATH is set, it would be`/<basepath>/wiki`

Then set `GLOBALS['wgWikiFarmConfig_defaultRedirect'] = '/de';` in /data/bluespice/pre-init-settings.php and it works again