### PR TITLE
Fix empty line in .wikienv

### DIFF
--- a/root-fs/app/bin/run-installation
+++ b/root-fs/app/bin/run-installation
@@ -19,7 +19,7 @@ fi
 upgradeKey=$(tr -dc a-z0-9 </dev/urandom | head -c 16; echo)
 secretKey=$(tr -dc a-z0-9 </dev/urandom | head -c 64; echo)
 samlSecretSalt=$(tr -dc a-z0-9 </dev/urandom | head -c 64; echo)
-echo '' > /data/.wikienv
+:> /data/.wikienv
 echo "INTERNAL_WIKI_UPGRADEKEY=$upgradeKey" >> /data/.wikienv
 echo "INTERNAL_WIKI_SECRETKEY=$secretKey" >> /data/.wikienv
 echo "INTERNAL_SIMPLESAMLPHP_ADMIN_PASS=$adminPass" >> /data/.wikienv


### PR DESCRIPTION
Is there a specific reason for writing an empty line to .wikienv here?

This change would prevent

https://github.com/hallowelt/docker-bluespice-helper/blob/569ee8e84f5180a98f5c68a51bbf9cb9d7998dcf/root-fs/app/bin/prepare.d/040-ensure-wiki-secrets#L16

from breaking with

`line 16: legacy_env_vars["$key"]: bad array subscript`