### PR TITLE
Add php modules for PostgreSQL and SQLite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,10 +69,14 @@ RUN apk add \
 	php$VERSION-opcache \
 	php$VERSION-pdo \
 	php$VERSION-pdo_mysql \
+	php$VERSION-pdo_pgsql \
+	php$VERSION-pdo_sqlite \
+	php$VERSION-pgsql \
 	php$VERSION-phar \
 	php$VERSION-posix \
 	php$VERSION-session \
 	php$VERSION-simplexml \
+	php$VERSION-sqlite3 \
 	php$VERSION-tokenizer \
 	php$VERSION-xml \
 	php$VERSION-xml \


### PR DESCRIPTION
[5.2.x]

Reason:
1. These two are supported by MediaWiki, and are theoretically supported by most of our extensions and vendor libraries.
2. Extension [External Data](https://www.mediawiki.org/wiki/Extension:External_Data) supports fetching data from an external database - for example a standalone Postgres database. Without these drivers, the connection cannot work.

External Data might use two more external libraries that we don't have in our image:
- `obdc` and related things, see https://www.mediawiki.org/wiki/Extension:External_Data/Databases#Microsoft_SQL_Server_2
- `SOAP`, which is useful for part of https://www.mediawiki.org/wiki/Extension:External_Data/Web_pages