### PR TITLE
(Cherry-pick from #113) Set ENV var defaults in a central place

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ docker build \
 | `DB_HOST`                    | `database`     | Database host                                        | Yes      |
 | `DB_NAME`                    | `bluespice`    | Database name                                        | Yes      |
 | `DB_PASS`                    | `null`         | Database password                                    | No       |
-| `DB_PREFIX`                  | `''`           | Database prefix ***)                                  | Yes      |
-| `DB_ROOT_PASS`               | ``             | Database root password ***)                           | Yes      |
-| `DB_ROOT_USER`               | ``             | Database root user                                   | Yes      |
+| `DB_PREFIX`                  | `''`           | Database prefix ***)                                 | Yes      |
+| `DB_ROOT_PASS`               | ``             | Database root password ***)                          | Yes      |
+| `DB_ROOT_USER`               | `root`         | Database root user                                   | Yes      |
 | `DB_TYPE`                    | `mysql`        | Database type                                        | Yes      |
 | `DB_USER`                    | `bluespice`    | Database user                                        | Yes      |
 | `DEV_WIKI_DEBUG`             | `null`         | Enable debug mode                                    | Yes      |

--- a/root-fs/app/bin/entrypoint
+++ b/root-fs/app/bin/entrypoint
@@ -15,11 +15,8 @@ echo "🚀 BlueSpice $blueSpiceEdition $blueSpiceVersion+$blueSpiceBuildInfo"
 echo "---------------------------------------------"
 echo ""
 
-if [ -z "$WIKI_PROXY" ]; then
-  export WIKI_PROXY=$(getent hosts proxy | awk '{ print $1 ; exit }')
-fi
+init-envs
 
-export PATH=$PATH:/app/bin
 substitutePlaceholders /app/bin/config/clamd.conf
 
 if [ -f /data/.wikienv ]; then

--- a/root-fs/app/bin/init-database
+++ b/root-fs/app/bin/init-database
@@ -4,7 +4,7 @@
 $dbHost = getenv('DB_HOST');
 $dbUser = getenv('DB_USER');
 $dbName = getenv('DB_NAME');
-$dbNamePrefix = getenv('WIKI_FARM_DB_PREFIX') ?: 'sfr_';
+$dbNamePrefix = getenv('WIKI_FARM_DB_PREFIX');
 // Attention: In contrast to the `install-database` script, we must not fall
 // back to `DB_USER`/`DB_PASS` here, as these operations require real root privileges.
 $dbRootUser = getenv('DB_ROOT_USER');

--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Antivirus service defaults
+export AV_HOST=${AV_HOST:--}
+export AV_PORT=${AV_PORT:-3310}
+
+# Backup defaults
+export BACKUP_HOUR=${BACKUP_HOUR:-1}
+
+# Cache service defaults
+export CACHE_HOST=${CACHE_HOST:-cache}
+export CACHE_PORT=${CACHE_PORT:-11211}
+
+# Chat defaults
+export CHAT_HOST=${CHAT_HOST:-chat}
+export CHAT_PORT=${CHAT_PORT:-3000}
+export CHAT_PROTOCOL=${CHAT_PROTOCOL:-http}
+
+# Database defaults
+export DB_HOST=${DB_HOST:-database}
+export DB_NAME=${DB_NAME:-bluespice}
+# DB_PASS is mandatory and has no default value
+export DB_PREFIX=${DB_PREFIX:-}
+export DB_ROOT_PASS=${DB_ROOT_PASS:-}
+export DB_ROOT_USER=${DB_ROOT_USER:-root}
+export DB_TYPE=${DB_TYPE:-mysql}
+export DB_USER=${DB_USER:-bluespice}
+
+# Development/Debug defaults
+export DEV_WIKI_DEBUG=${DEV_WIKI_DEBUG:-}
+export DEV_WIKI_DEBUG_LOGCHANNELS=${DEV_WIKI_DEBUG_LOGCHANNELS:-}
+
+# Diagram service defaults (depend on WIKI_* vars, set later)
+# Additional ones see below
+export DIAGRAM_PATH=${DIAGRAM_PATH:-/_diagram/}
+
+# Edition defaults
+export EDITION=${EDITION:-}
+
+# Formula service defaults
+export FORMULA_HOST=${FORMULA_HOST:-formula}
+export FORMULA_PORT=${FORMULA_PORT:-10044}
+export FORMULA_PROTOCOL=${FORMULA_PROTOCOL:-http}
+
+# PDF service defaults
+export PDF_HOST=${PDF_HOST:-pdf}
+export PDF_PORT=${PDF_PORT:-8080}
+export PDF_PROTOCOL=${PDF_PROTOCOL:-http}
+
+# Search service defaults
+export SEARCH_HOST=${SEARCH_HOST:-search}
+export SEARCH_PASS=${SEARCH_PASS:-}
+export SEARCH_PORT=${SEARCH_PORT:-9200}
+export SEARCH_PROTOCOL=${SEARCH_PROTOCOL:-http}
+export SEARCH_USER=${SEARCH_USER:-}
+
+# SMTP defaults
+export SMTP_HOST=${SMTP_HOST:-}
+export SMTP_IDHOST=${SMTP_IDHOST:-}
+export SMTP_PASS=${SMTP_PASS:-}
+export SMTP_PORT=${SMTP_PORT:-25}
+export SMTP_USER=${SMTP_USER:-}
+
+# Timezone defaults
+export TZ=${TZ:-UTC}
+
+# Wiki defaults
+export WIKI_BASE_PATH=${WIKI_BASE_PATH:-/}
+export WIKI_EMERGENCYCONTACT=${WIKI_EMERGENCYCONTACT:-}
+export WIKI_FARM_DB_PREFIX=${WIKI_FARM_DB_PREFIX:-sfr_}
+export WIKI_FARM_USE_SHARED_DB=${WIKI_FARM_USE_SHARED_DB:-}
+export WIKI_HOST=${WIKI_HOST:-localhost}
+export WIKI_INITIAL_ADMIN_PASS=${WIKI_INITIAL_ADMIN_PASS:-}
+export WIKI_INITIAL_ADMIN_USER=${WIKI_INITIAL_ADMIN_USER:-Admin}
+export WIKI_LANG=${WIKI_LANG:-en}
+export WIKI_LOG_LEVEL=${WIKI_LOG_LEVEL:-error}
+export WIKI_NAME=${WIKI_NAME:-BlueSpice}
+export WIKI_OAUTH2_PRIVATE_KEY_FILE=${WIKI_OAUTH2_PRIVATE_KEY_FILE:-/data/bluespice/oauth_private.key}
+export WIKI_OAUTH2_PUBLIC_KEY_FILE=${WIKI_OAUTH2_PUBLIC_KEY_FILE:-/data/bluespice/oauth_public.key}
+export WIKI_PORT=${WIKI_PORT:-443}
+export WIKI_POST_INIT_SETTINGS_FILE=${WIKI_POST_INIT_SETTINGS_FILE:-/data/bluespice/post-init-settings.php}
+export WIKI_PRE_INIT_SETTINGS_FILE=${WIKI_PRE_INIT_SETTINGS_FILE:-/data/bluespice/pre-init-settings.php}
+export WIKI_PROTOCOL=${WIKI_PROTOCOL:-https}
+export WIKI_SUBSCRIPTION_KEY=${WIKI_SUBSCRIPTION_KEY:-}
+export WIKI_STATUSCHECK_ALLOWED=${WIKI_STATUSCHECK_ALLOWED:-}
+
+# WIKI_PROXY - more sophisticated detection
+if [ -z "$WIKI_PROXY" ]; then
+  export WIKI_PROXY=$(getent hosts proxy | awk '{ print $1 ; exit }')
+fi
+
+# WIKI_PASSWORDSENDER - depends on WIKI_HOST
+export WIKI_PASSWORDSENDER=${WIKI_PASSWORDSENDER:-no-reply@$WIKI_HOST}
+
+# Wire defaults
+export WIRE_HOST=${WIRE_HOST:-wire}
+export WIRE_PORT=${WIRE_PORT:-3333}
+export WIRE_PROTOCOL=${WIRE_PROTOCOL:-http}
+
+# Diagram service defaults that depend on WIKI_* vars
+export DIAGRAM_HOST=${DIAGRAM_HOST:-$WIKI_HOST}
+export DIAGRAM_PORT=${DIAGRAM_PORT:-$WIKI_PORT}
+export DIAGRAM_PROTOCOL=${DIAGRAM_PROTOCOL:-$WIKI_PROTOCOL}
+
+# Path adjustments
+export PATH=$PATH:/app/bin

--- a/root-fs/app/conf/LocalSettings.php
+++ b/root-fs/app/conf/LocalSettings.php
@@ -3,35 +3,29 @@ if ( !defined( 'MEDIAWIKI' ) ) {
 	exit;
 }
 
-$GLOBALS['wgServer'] = bsAssembleURL(
-	[ 'WIKI_PROTOCOL', 'https' ],
-	[ 'WIKI_HOST', 'localhost' ],
-	[ 'WIKI_PORT', '443' ]
-);
-
-$GLOBALS['wgSitename'] = trim(  getenv( 'WIKI_NAME' ) ?: 'BlueSpice' );
-$GLOBALS['wgScriptPath'] = ( trim(  getenv( 'WIKI_BASE_PATH' ) ?: '/' ) ) .'w';
+$GLOBALS['wgServer'] = bsAssembleURL( 'WIKI_PROTOCOL', 'WIKI_HOST', 'WIKI_PORT' );
+$GLOBALS['wgSitename'] = trim(  getenv( 'WIKI_NAME' ) );
+$GLOBALS['wgScriptPath'] = ( trim(  getenv( 'WIKI_BASE_PATH' ) ) ) .'w';
 
 $GLOBALS['wgResourceBasePath'] = $GLOBALS['wgScriptPath'];
 $GLOBALS['wgLogos'] = [
 	'1x' => $GLOBALS['wgResourceBasePath'] . '/resources/assets/change-your-logo.svg',
 	'icon' => $GLOBALS['wgResourceBasePath']. '/resources/assets/change-your-logo-icon.svg',
 ];
-$GLOBALS['wgEmergencyContact'] = trim( getenv( 'WIKI_EMERGENCYCONTACT' ) ?: '' );
-$GLOBALS['wgPasswordSender'] = trim( getenv( 'WIKI_PASSWORDSENDER' )
-	?: 'no-reply@' . trim ( getenv( 'WIKI_HOST' ) ?: 'localhost' ) );
-$GLOBALS['wgDBtype'] = trim( getenv( 'DB_TYPE' ) ?: 'mysql' );
-$GLOBALS['wgDBserver'] = trim( getenv( 'DB_HOST' ) ?: 'database' );
-$GLOBALS['wgDBname'] = trim( getenv( 'DB_NAME' ) ?: 'bluespice' );
-$GLOBALS['wgDBuser'] = trim( getenv( 'DB_USER' ) ?: 'bluespice' );
+$GLOBALS['wgEmergencyContact'] = trim( getenv( 'WIKI_EMERGENCYCONTACT' ) );
+$GLOBALS['wgPasswordSender'] = trim( getenv( 'WIKI_PASSWORDSENDER' ) );
+$GLOBALS['wgDBtype'] = trim( getenv( 'DB_TYPE' ) );
+$GLOBALS['wgDBserver'] = trim( getenv( 'DB_HOST' ) );
+$GLOBALS['wgDBname'] = trim( getenv( 'DB_NAME' ) );
+$GLOBALS['wgDBuser'] = trim( getenv( 'DB_USER' ) );
 $GLOBALS['wgDBpassword'] = trim(  getenv( 'DB_PASS' ) );
-$GLOBALS['wgDBprefix'] = trim(  getenv( 'DB_PREFIX' ) ?: '' );
+$GLOBALS['wgDBprefix'] = trim(  getenv( 'DB_PREFIX' ) );
 $GLOBALS['wgDBTableOptions'] = "ENGINE=InnoDB, DEFAULT CHARSET=binary";
 $GLOBALS['wgMainCacheType'] = CACHE_ACCEL;
 $GLOBALS['wgSessionCacheType'] = CACHE_DB;
 if ( getenv( 'CACHE_HOST' ) !== '-' ) {
-	$cacheHost = trim( getenv( 'CACHE_HOST' ) ?: 'cache' );
-	$cachePort = trim( getenv( 'CACHE_PORT' ) ?: '11211' );
+	$cacheHost = trim( getenv( 'CACHE_HOST' ) );
+	$cachePort = trim( getenv( 'CACHE_PORT' ) );
 	$GLOBALS['wgMemCachedServers'] = [ "$cacheHost:$cachePort" ];
 	unset( $cacheHost );
 	unset( $cachePort );
@@ -45,7 +39,7 @@ $GLOBALS['wgEnableUploads'] = true;
 $GLOBALS['wgUploadPath'] = $GLOBALS['wgScriptPath'] . '/img_auth.php';
 $GLOBALS['wgUseImageMagick'] = true;
 $GLOBALS['wgImageMagickConvertCommand'] = "/usr/bin/magick";
-$GLOBALS['wgLanguageCode'] = trim( getenv( 'WIKI_LANG' ) ?: 'en' );
+$GLOBALS['wgLanguageCode'] = trim( getenv( 'WIKI_LANG' ) );
 $GLOBALS['wgLocaltimezone'] = null;
 $GLOBALS['wgSecretKey'] = trim( getenv( 'INTERNAL_WIKI_SECRETKEY' ) );
 $GLOBALS['wgAuthenticationTokenVersion'] = "1";
@@ -59,12 +53,12 @@ $GLOBALS['wgPhpCli'] = '/bin/php';
 $GLOBALS['wgSMTP'] = [
 	'host' => trim( getenv( 'SMTP_HOST' ) ),
 	'IDHost' => trim( getenv( 'SMTP_IDHOST' ) ),
-	'port' => trim( getenv( 'SMTP_PORT' ) ?: 25 ),
+	'port' => trim( getenv( 'SMTP_PORT' ) ),
 	'auth' => getenv( 'SMTP_USER' ) ? true : false,
 	'username' => trim( getenv( 'SMTP_USER' ) ),
 	'password' => trim( getenv( 'SMTP_PASS' ) ),
 ];
-if ( getenv( 'AV_HOST' ) ) {
+if ( getenv( 'AV_HOST' ) !== '-' ) {
 	$GLOBALS['wgAntivirusSetup'] = [
 		'clamav' => [
 			'command' => 'clamdscan --no-summary',
@@ -92,20 +86,16 @@ if ( getenv( 'WIKI_SUBSCRIPTION_KEY' ) ) {
 	$GLOBALS['bsgOverrideLicenseKey'] = trim( getenv( 'WIKI_SUBSCRIPTION_KEY' ) ) ;
 }
 
-$GLOBALS['wgOAuth2PrivateKey'] = getenv( 'INTERNAL_OAUTH2_PRIVATE_KEY' ) ?: '/data/bluespice/oauth_private.key';
-$GLOBALS['wgOAuth2PublicKey'] = getenv( 'INTERNAL_OAUTH2_PUBLIC_KEY' ) ?: '/data/bluespice/oauth_public.key';
+$GLOBALS['wgOAuth2PrivateKey'] = trim( getenv( 'WIKI_OAUTH2_PRIVATE_KEY_FILE' ) );
+$GLOBALS['wgOAuth2PublicKey'] = trim( getenv( 'WIKI_OAUTH2_PUBLIC_KEY_FILE' ) );
 
-$GLOBALS['bsgESBackendHost'] = trim( getenv( 'SEARCH_HOST' ) ?: 'search' );
-$GLOBALS['bsgESBackendPort'] = trim( getenv( 'SEARCH_PORT' ) ?: '9200' );
-$GLOBALS['bsgESBackendTransport'] = trim( getenv( 'SEARCH_PROTOCOL' ) ?: 'http' );
-$GLOBALS['bsgESBackendUsername'] = trim( getenv( 'SEARCH_USER' ) ?: '' );
-$GLOBALS['bsgESBackendPassword'] = trim( getenv( 'SEARCH_PASS' ) ?: '' );
+$GLOBALS['bsgESBackendHost'] = trim( getenv( 'SEARCH_HOST' ) );
+$GLOBALS['bsgESBackendPort'] = trim( getenv( 'SEARCH_PORT' ) );
+$GLOBALS['bsgESBackendTransport'] = trim( getenv( 'SEARCH_PROTOCOL' ) );
+$GLOBALS['bsgESBackendUsername'] = trim( getenv( 'SEARCH_USER' ) );
+$GLOBALS['bsgESBackendPassword'] = trim( getenv( 'SEARCH_PASS' ) );
 
-$GLOBALS['wgPDFCreatorOpenHtml2PdfServiceUrl'] = bsAssembleURL(
-	[ 'PDF_PROTOCOL', 'http' ],
-	[ 'PDF_HOST', 'pdf' ],
-	[ 'PDF_PORT', '8080' ]
-);
+$GLOBALS['wgPDFCreatorOpenHtml2PdfServiceUrl'] = bsAssembleURL( 'PDF_PROTOCOL', 'PDF_HOST', 'PDF_PORT' );
 $GLOBALS['wgPDFCreatorOpenHtml2PdfServiceUrl'] .= '/Html2PDF/v1';
 
 $GLOBALS['wgPdfProcessor'] = '/usr/bin/gs';
@@ -115,13 +105,7 @@ $GLOBALS['wgPdftoText'] = '/usr/bin/pdftotext';
 
 if ( getenv( 'EDITION' ) !== 'free' ) {
 	// FREE edition uses public diagrams.net service
-	// HINT: Keep in sync with assembly of $GLOBALS['wgServer']
-	$GLOBALS['wgDrawioEditorBackendUrl'] = bsAssembleURL(
-		[ 'DIAGRAM_PROTOCOL', trim( getenv( 'WIKI_PROTOCOL' ) ?: 'https' ) ],
-		[ 'DIAGRAM_HOST', trim( getenv( 'WIKI_HOST' ) ?: 'localhost' ) ],
-		[ 'DIAGRAM_PORT', trim( getenv( 'WIKI_PORT' ) ?: '443' ) ],
-		[ 'DIAGRAM_PATH', '/_diagram/' ]
-	);
+	$GLOBALS['wgDrawioEditorBackendUrl'] = bsAssembleURL( 'DIAGRAM_PROTOCOL', 'DIAGRAM_HOST', 'DIAGRAM_PORT', 'DIAGRAM_PATH' );
 }
 
 $GLOBALS['wgMathValidModes'] = [ 'mathml' ];
@@ -130,11 +114,7 @@ $GLOBALS['wgMaxShellMemory'] = 1228800;
 $GLOBALS['wgHiddenPrefs'][] = 'math';
 // We don't use the `MathMathML` renderer, but `MathMathMLCli`,
 // but `Extension:BlueSpiceInstanceStatus` needs this variable
-$GLOBALS['wgMathMathMLUrl'] = bsAssembleURL(
-	[ 'FORMULA_PROTOCOL', 'http' ],
-	[ 'FORMULA_HOST', 'formula' ],
-	[ 'FORMULA_PORT', '10044' ]
-);
+$GLOBALS['wgMathMathMLUrl'] = bsAssembleURL( 'FORMULA_PROTOCOL', 'FORMULA_HOST', 'FORMULA_PORT' );
 // By setting `$wgMathoidCli`, `MathMathMLCli` renderer is used
 // instead of `MathMathML`.
 $GLOBALS['wgMathoidCli'] = [
@@ -142,9 +122,7 @@ $GLOBALS['wgMathoidCli'] = [
 	$GLOBALS['wgMathMathMLUrl']
 ];
 
-$GLOBALS['bsgInstanceStatusCheckAllowedIP'] =
-	trim( getenv( 'WIKI_STATUSCHECK_ALLOWED' ) )
-	?? Wikimedia\IPUtils::sanitizeRange( $_SERVER['SERVER_ADDR'] . '/24' );
+$GLOBALS['bsgInstanceStatusCheckAllowedIP'] = trim( getenv( 'WIKI_STATUSCHECK_ALLOWED' ) );
 
 
 $GLOBALS['wgSimpleSAMLphp_InstallDir'] = '/app/simplesamlphp';
@@ -178,10 +156,10 @@ if ( getenv( 'EDITION' ) === 'farm' ) {
 	$GLOBALS['wgWikiFarmConfig_archiveDirectory'] = '/data/bluespice/farm-archives/';
 	$GLOBALS['wgWikiFarmConfig_dbAdminUser'] = trim( getenv( 'DB_ROOT_USER' ) ?: $GLOBALS['wgDBuser'] );
 	$GLOBALS['wgWikiFarmConfig_dbAdminPassword'] = trim( getenv( 'DB_ROOT_PASS' ) ?: $GLOBALS['wgDBpassword'] );
-	$GLOBALS['wgWikiFarmConfig_dbPrefix'] = trim( getenv( 'WIKI_FARM_DB_PREFIX' ) ?: 'sfr_' );
+	$GLOBALS['wgWikiFarmConfig_dbPrefix'] = trim( getenv( 'WIKI_FARM_DB_PREFIX' ) );
 	$GLOBALS['wgWikiFarmConfig_LocalSettingsAppendPath'] = "$IP/LocalSettings.BlueSpice.php";
 	$GLOBALS['wgWikiFarmConfig_useSharedDB'] = getenv( 'WIKI_FARM_USE_SHARED_DB' ) ? true : false;
-	$GLOBALS['wgWikiFarmConfig_basePath'] = trim( getenv( 'WIKI_BASE_PATH' ) ?: '' );
+	$GLOBALS['wgWikiFarmConfig_basePath'] = trim( getenv( 'WIKI_BASE_PATH' ) );
 	$GLOBALS['wgSharedDB'] = $GLOBALS['wgDBname'];
 	$GLOBALS['wgSharedPrefix'] = $GLOBALS['wgDBprefix'];
 	$GLOBALS['wgSharedTables'] = [ 'bs_translationtransfer_translations' ];
@@ -208,11 +186,7 @@ $GLOBALS['mwsgTokenAuthenticatorServiceCIDR'] =
 
 // `bluespice/wire` service configuration
 $GLOBALS['mwsgWireServiceApiKey'] = getenv( 'INTERNAL_WIRE_API_KEY' );
-$GLOBALS['mwsgWireServiceUrl'] = bsAssembleURL(
-	[ 'WIRE_PROTOCOL', 'http' ],
-	[ 'WIRE_HOST', 'wire' ],
-	[ 'WIRE_PORT', '3333' ]
-);
+$GLOBALS['mwsgWireServiceUrl'] = bsAssembleURL( 'WIRE_PROTOCOL', 'WIRE_HOST', 'WIRE_PORT' );
 $GLOBALS['mwsgWireServiceWebsocketUrl'] = $GLOBALS[ 'wgServer' ] . '/_wire';
 
 // Extension:WikiRAG configuration
@@ -228,11 +202,7 @@ $GLOBALS['wgWikiRAGPipeline'] = [ 'content.wikitext', 'repofile', 'meta.json', '
 if ( getenv( 'CHAT_HOST' ) !== '-' ) {
 	// Extension:ChatIntegration configuration
 	$GLOBALS['wgChatIntegrationBridge'] = [
-		'url' => bsAssembleURL(
-			[ 'CHAT_PROTOCOL', 'http' ],
-			[ 'CHAT_HOST', 'chat' ],
-			[ 'CHAT_PORT', '3000' ]
-		),
+		'url' => bsAssembleURL( 'CHAT_PROTOCOL', 'CHAT_HOST', 'CHAT_PORT' ),
 		'token' => getenv( 'INTERNAL_CHAT_TOKEN' )
 	];
 
@@ -242,7 +212,7 @@ if ( getenv( 'CHAT_HOST' ) !== '-' ) {
 	];
 }
 
-require_once '/data/bluespice/pre-init-settings.php';
+require_once trim( getenv( 'WIKI_PRE_INIT_SETTINGS_FILE' ) );
 if ( getenv( 'EDITION' ) === 'farm' ) {
 	require_once "$IP/extensions/BlueSpiceWikiFarm/WikiFarm.setup.php";
 }
@@ -254,12 +224,12 @@ else {
 	require_once "$IP/LocalSettings.BlueSpice.php";
 }
 
-$GLOBALS['wgArticlePath'] = ( trim(  getenv( 'WIKI_BASE_PATH' ) ?: '/' ) ) . 'wiki/$1';
+$GLOBALS['wgArticlePath'] = ( trim(  getenv( 'WIKI_BASE_PATH' ) ) ) . 'wiki/$1';
 if ( getenv( 'EDITION' ) === 'farm' ) {
 	if( FARMER_IS_ROOT_WIKI_CALL === false ) {
-		$GLOBALS['wgScriptPath'] =  trim( getenv( 'WIKI_BASE_PATH' ) ?: '/' ) . FARMER_CALLED_INSTANCE;
-		$GLOBALS['wgArticlePath'] = trim( getenv( 'WIKI_BASE_PATH' ) ?: '/' ) . FARMER_CALLED_INSTANCE . '/wiki/$1';
-		$GLOBALS['wgWebDAVBaseUri'] = trim( getenv( 'WIKI_BASE_PATH' ) ?: '/' ) . FARMER_CALLED_INSTANCE . '/webdav/';
+		$GLOBALS['wgScriptPath'] =  trim( getenv( 'WIKI_BASE_PATH' ) ) . FARMER_CALLED_INSTANCE;
+		$GLOBALS['wgArticlePath'] = trim( getenv( 'WIKI_BASE_PATH' ) ) . FARMER_CALLED_INSTANCE . '/wiki/$1';
+		$GLOBALS['wgWebDAVBaseUri'] = trim( getenv( 'WIKI_BASE_PATH' ) ) . FARMER_CALLED_INSTANCE . '/webdav/';
 		// We must store L10N cache file of ROOT_WIKI and INSTANCEs independently, as they have different extensions enabled,
 		// which otherwise causes the cache to be invalidated all the time.
 		$GLOBALS['wgLocalisationCacheConf']['storeDirectory'] = '/tmp/cache/l10n-instances';
@@ -286,4 +256,4 @@ if ( getenv( 'MAX_UPLOAD_SIZE' ) ) {
 	unset( $matches );
 }
 
-require_once '/data/bluespice/post-init-settings.php';
+require_once trim( getenv( 'WIKI_POST_INIT_SETTINGS_FILE' ) );

--- a/root-fs/app/conf/init.php
+++ b/root-fs/app/conf/init.php
@@ -24,7 +24,40 @@ if ( isset( $_REQUEST['_profiler'] ) ) {
 	} );
 }
 
+/**
+ * Assembles a URL from ENV variables. Parameters can either be
+ * the ENV variable names as strings, or arrays with the ENV
+ * variable names as the first element and a fallback value as
+ * the second element.
+ *
+ * Examples:
+ * ```
+ *	$GLOBALS['wgServer'] = bsAssembleURL( 'WIKI_PROTOCOL', 'WIKI_HOST','WIKI_PORT' );
+ * ```
+ *
+ * ```
+ *	$GLOBALS['wgServer'] = bsAssembleURL(
+ *		[ 'WIKI_PROTOCOL', 'https' ],
+ *		[ 'WIKI_HOST', 'localhost' ],
+ *		[ 'WIKI_PORT', '443' ]
+ *	);
+ * ```
+ *
+ * @param array|string $proto
+ * @param array|string $hostname
+ * @param array|string $port
+ * @param array|string $path
+ * @return string The assembled URL
+ */
 function bsAssembleURL( $proto, $hostname, $port, $path = [] ) {
+
+	// Allow for ENV variable names without fallback, as fallbacks are now
+	// set centrally in `/app/bin/init-envs`
+	$proto = is_string( $proto ) ? [ $proto, '' ] : $proto;
+	$hostname = is_string( $hostname ) ? [ $hostname, '' ] : $hostname;
+	$port = is_string( $port ) ? [ $port, '' ] : $port;
+	$path = is_string( $path ) ? [ $path, '' ] : $path;
+
 	$protocol = trim( getenv( $proto[0] ) ?: $proto[1] );
 	$host = trim( getenv( $hostname[0] ) ?: $hostname[1] );
 	if ( !empty( $path ) ) {

--- a/root-fs/app/simplesamlphp/config/authsources.php
+++ b/root-fs/app/simplesamlphp/config/authsources.php
@@ -2,11 +2,7 @@
 
 $idpRemoteMetaData = require( __DIR__ . '/_bluespice-saml20-idp-remote-meta.php' );
 
-$baseUrl = $GLOBALS['wgServer'] = bsAssembleURL(
-	[ 'WIKI_PROTOCOL', 'https' ],
-	[ 'WIKI_HOST', 'localhost' ],
-	[ 'WIKI_PORT', '443' ]
-);
+$baseUrl = $GLOBALS['wgServer'] = bsAssembleURL( 'WIKI_PROTOCOL', 'WIKI_HOST', 'WIKI_PORT' );
 
 $config = [
 	'admin' => [

--- a/root-fs/app/simplesamlphp/config/config.php
+++ b/root-fs/app/simplesamlphp/config/config.php
@@ -2,11 +2,7 @@
 
 include (__DIR__ . '/config.php.dist');
 
-$baseUrl = $GLOBALS['wgServer'] = bsAssembleURL(
-	[ 'WIKI_PROTOCOL', 'https' ],
-	[ 'WIKI_HOST', 'localhost' ],
-	[ 'WIKI_PORT', '443' ]
-);
+$baseUrl = $GLOBALS['wgServer'] = bsAssembleURL( 'WIKI_PROTOCOL', 'WIKI_HOST', 'WIKI_PORT' );
 
 // TODO calculate from environment variable
 $loglevel = SimpleSAML\Logger::WARNING;
@@ -35,11 +31,11 @@ $customConfig = [
 	'session.cookie.secure' => true,
 	'session.cookie.name' =>
 		getenv('DB_NAME') .
-		( getenv('DB_PREFIX') ?? '' ) .
+		( getenv('DB_PREFIX') ) .
 		'SAMLSessionID',
 	'session.authtoken.cookiename' =>
 		getenv('DB_NAME') .
-		( getenv('DB_PREFIX') ?? '' ) .
+		( getenv('DB_PREFIX') ) .
 		'SAMLAuthToken',
 	'enable.http_post' => true,
 	'secretsalt' => getenv('INTERNAL_SIMPLESAMLPHP_SECRET_SALT'),
@@ -59,23 +55,23 @@ $customConfig = [
 	'showerrors' => getenv( 'DEV_WIKI_DEBUG' ) ?: false,
 	'errorreporting' => true,
 
-	'technicalcontact_name' => getenv('WIKI_NAME') ?? 'BlueSpice',
-	'technicalcontact_email' => getenv('WIKI_EMERGENCYCONTACT') ?? '',
+	'technicalcontact_name' => getenv('WIKI_NAME'),
+	'technicalcontact_email' => getenv('WIKI_EMERGENCYCONTACT'),
 	'mail.transport.method' => 'smtp',
 	'mail.transport.options' => [
 		'host' => getenv( 'SMTP_HOST' ),
-		'port' => getenv( 'SMTP_PORT' ) ?: 25,
+		'port' => getenv( 'SMTP_PORT' ),
 		'username' => getenv( 'SMTP_USER' ),
 		'password' => getenv( 'SMTP_PASS' ),
 		'security' => 'tls'
 	],
-	'sendmail_from' => getenv('WIKI_EMERGENCYCONTACT') ?: '',
+	'sendmail_from' => getenv('WIKI_EMERGENCYCONTACT'),
 
 	'store.type' => 'sql',
-	'store.sql.dsn' => 'mysql:dbname=' . (getenv('DB_NAME') ?? 'database') . ';host=' . getenv('DB_HOST'),
+	'store.sql.dsn' => 'mysql:dbname=' . ( getenv('DB_NAME') ) . ';host=' . getenv('DB_HOST'),
 	'store.sql.username' => getenv('DB_USER'),
 	'store.sql.password' => getenv('DB_PASS'),
-	'store.sql.prefix' => (getenv('DB_PREFIX') ?? '') . 'SimpleSAMLphp_',
+	'store.sql.prefix' => ( getenv('DB_PREFIX') ) . 'SimpleSAMLphp_',
 ];
 
 $config = $customConfig + $config;


### PR DESCRIPTION
* Set ENV var defaults in a central place

Fixes https://github.com/hallowelt/docker-bluespice-wiki/issues/92

* Remove fallbacks from PHP # 1

* Remove fallbacks from PHP # 2

* Allow setting config file paths

This is required to allow setups without `/data` mount, e.g. when using "secrets" or "ConfigMaps"

* Fix default DB_ROOT_USER

* Cherry-pick to branch MergeCentralizedEnvs

New defalut env mechanism is also used for chat and wire

---------