### PR TITLE
Add default fallback favicon

### DIFF
--- a/root-fs/app/conf/nginx_bluespice
+++ b/root-fs/app/conf/nginx_bluespice
@@ -11,6 +11,7 @@ server {
 	error_log /proc/1/fd/2 ###WIKI_LOG_LEVEL###;
 	server_tokens off;
 
+	rewrite ^/favicon\.ico$ ###WIKI_BASE_PATH|/###w/skins/BlueSpiceDiscovery/resources/images/favicon.ico last;
 	rewrite ^###WIKI_BASE_PATH|/###robots\.txt$ ###WIKI_BASE_PATH|/###robots.txt last;
 	rewrite ^###WIKI_BASE_PATH|/###_sp/(.*)$ ###WIKI_BASE_PATH|/###_sp/$1 last;
 	rewrite ^###WIKI_BASE_PATH|/###webdav/(.*)$ ###WIKI_BASE_PATH|/###w/webdav.php/$1?$args last;


### PR DESCRIPTION
for requests that does not return html,
hence does not provide chance to serve
customer defined favicon link.
Browsers ask for /favicon.ico by default,
which should not trigger any MediaWiki
requests / login redirects

ERM46324, ERM46400

[5.1.x]