### PR TITLE
Use `WIKI_BASE_PATH` for `mwsgWireServiceWebsocketUrl`

### DIFF
--- a/root-fs/app/conf/LocalSettings.php
+++ b/root-fs/app/conf/LocalSettings.php
@@ -191,7 +191,7 @@ $GLOBALS['mwsgTokenAuthenticatorServiceCIDR'] =
 // `bluespice/wire` service configuration
 $GLOBALS['mwsgWireServiceApiKey'] = getenv( 'INTERNAL_WIRE_API_KEY' );
 $GLOBALS['mwsgWireServiceUrl'] = bsAssembleURL( 'WIRE_PROTOCOL', 'WIRE_HOST', 'WIRE_PORT' );
-$GLOBALS['mwsgWireServiceWebsocketUrl'] = $GLOBALS[ 'wgServer' ] . '/_wire';
+$GLOBALS['mwsgWireServiceWebsocketUrl'] = $GLOBALS[ 'wgServer' ] . ( trim( getenv( 'WIKI_BASE_PATH' ) ?: '/' ) ) . '_wire';
 
 // Extension:WikiRAG configuration
 $GLOBALS['wgWikiRAGTarget'] = [


### PR DESCRIPTION
Is already in 

https://github.com/hallowelt/bluespice-deploy/blob/b5b889c2f6a818157cbb4911a84584c6de337e9c/compose/docker-compose.proxy.yml#L27

```
  wire:
    environment:
      VIRTUAL_HOST: ${WIKI_HOST}
      VIRTUAL_PATH: ${WIKI_BASE_PATH:-/}_wire
      VIRTUAL_PORT: 3333
      VIRTUAL_DEST: /
```