### PR TITLE
Prevent variable expansion in heredoc

### DIFF
--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-cat <<EOF >> /app/.env
+cat <<'EOF' >> /app/.env
 # Antivirus service defaults
 export AV_HOST=${AV_HOST:--}
 export AV_PORT=${AV_PORT:-3310}


### PR DESCRIPTION
Since there is no reason to expand the variables inside the script `init-envs`, they can instead be expanded when the file is sourced.

Fixes https://github.com/hallowelt/docker-bluespice-wiki/issues/134
Closes https://github.com/hallowelt/docker-bluespice-wiki/pull/138