### PR TITLE
Wait for /data/.wikienv before populating /app/.env

### DIFF
--- a/root-fs/app/bin/start-web
+++ b/root-fs/app/bin/start-web
@@ -22,6 +22,14 @@ case "${WIKI_LOG_LEVEL}" in
     ;;
 esac
 
+while [ ! -s /data/.wikienv ]; do
+    sleep 5
+    echo "Waiting for wikienv to be created by wiki-task..."
+done
+
+init-envs
+source /app/.env
+
 substitutePlaceholders /app/conf/90-bluespice-overrides.ini
 substitutePlaceholders /app/conf/nginx_bluespice
 


### PR DESCRIPTION
https://github.com/hallowelt/docker-bluespice-wiki/blob/6c2fd0e227521083740dc5cb2de2c9a434c7f87e/root-fs/app/bin/entrypoint#L18 
when wiki-web starts, /data/.wikienv will not yet exist because it has not been created by wiki-task.