### PR TITLE
Use lazy image loading and thumb generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV MEDIAWIKIADM_SHA256=c038de94ce49c66584556bc03c58bf0f9388d109b9428c800d0b74c9
 ENV PARALLELRUNJOBSSERVICE_URL=https://github.com/hallowelt/misc-parallel-runjobs-service/releases/latest/download/parallel-runjobs-service
 ENV PARALLELRUNJOBSSERVICE_SHA256=ec8ea7e8a79242baba862448bcba952376267c0db19785d6266ab9a01a29e241
 
-ARG BLUESPICE_VERSION=5.2.4
+ARG BLUESPICE_VERSION=5.2.3
 ARG BLUESPICE_URL=https://github.com/BlueSpice-Wiki/bluespice-free-release.git
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV MEDIAWIKIADM_SHA256=c038de94ce49c66584556bc03c58bf0f9388d109b9428c800d0b74c9
 ENV PARALLELRUNJOBSSERVICE_URL=https://github.com/hallowelt/misc-parallel-runjobs-service/releases/latest/download/parallel-runjobs-service
 ENV PARALLELRUNJOBSSERVICE_SHA256=ec8ea7e8a79242baba862448bcba952376267c0db19785d6266ab9a01a29e241
 
-ARG BLUESPICE_VERSION=5.2.2
+ARG BLUESPICE_VERSION=5.2.4
 ARG BLUESPICE_URL=https://github.com/BlueSpice-Wiki/bluespice-free-release.git
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV MEDIAWIKIADM_SHA256=c038de94ce49c66584556bc03c58bf0f9388d109b9428c800d0b74c9
 ENV PARALLELRUNJOBSSERVICE_URL=https://github.com/hallowelt/misc-parallel-runjobs-service/releases/latest/download/parallel-runjobs-service
 ENV PARALLELRUNJOBSSERVICE_SHA256=ec8ea7e8a79242baba862448bcba952376267c0db19785d6266ab9a01a29e241
 
-ARG BLUESPICE_VERSION=5.2.3
+ARG BLUESPICE_VERSION=5.2.x
 ARG BLUESPICE_URL=https://github.com/BlueSpice-Wiki/bluespice-free-release.git
 
 WORKDIR /build

--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -116,7 +116,7 @@ fi
 # if /run/secrets/ exists
 if [ -d /run/secrets/ ]; then
   echo "# Secrets loaded from /run/secrets" >> /app/.env
-  for secret in $(find /run/secrets/ -maxdepth 1 -type f | grep -E '/[A-Z_]+$' | xargs -n1 basename); do
+  for secret in $(find /run/secrets/ -maxdepth 1 -type f | grep -E '/[A-Z_]+$' | xargs -n1 -r basename); do
     # For grep:
     # - INTERNAL_CHAT_TOKEN
     # - INTERNAL_SIMPLESAMLPHP_ADMIN_PASS

--- a/root-fs/app/conf/LocalSettings.php
+++ b/root-fs/app/conf/LocalSettings.php
@@ -37,6 +37,15 @@ $GLOBALS['wgLocalisationCacheConf']['store'] = 'array';
 $GLOBALS['wgLocalisationCacheConf']['storeDirectory'] = "/tmp/cache/l10n";
 $GLOBALS['wgEnableUploads'] = true;
 $GLOBALS['wgUploadPath'] = $GLOBALS['wgScriptPath'] . '/img_auth.php';
+// Use thumb.php for on-demand thumbnail creation instead of pre-generating at parse time.
+// transformVia404 is NOT used: that approach requires the web server to serve thumbnail files
+// directly from the filesystem (so a missing file triggers a 404 → handler chain). Since all
+// image delivery here goes through img_auth.php (a PHP entrypoint), there is no direct
+// filesystem serving — a 404 would mean the file truly does not exist, not merely that the
+// thumbnail hasn't been rendered yet. thumb.php is therefore the correct mechanism.
+$GLOBALS['wgThumbnailScriptPath'] = $GLOBALS['wgScriptPath'] . '/thumb.php';
+$GLOBALS['wgGenerateThumbnailOnParse'] = false;
+$GLOBALS['wgNativeImageLazyLoading'] = true;
 $GLOBALS['wgUseImageMagick'] = true;
 $GLOBALS['wgImageMagickConvertCommand'] = "/usr/bin/magick";
 $GLOBALS['wgLanguageCode'] = trim( getenv( 'WIKI_LANG' ) );

--- a/root-fs/app/conf/nginx_bluespice
+++ b/root-fs/app/conf/nginx_bluespice
@@ -53,7 +53,7 @@ server {
 		deny all;
 	}
 
-	location ~ ^###WIKI_BASE_PATH|/###w/(api|dynamic_file|index|load|opensearch_desc|thumb_handler|thumb)\.php$ {
+	location ~ ^###WIKI_BASE_PATH|/###w/(api|dynamic_file|index|load|opensearch_desc|thumb_handler|thumb|nsfr_thumb)\.php$ {
 		include fastcgi.conf;
 		fastcgi_split_path_info ^(.+?\.php)(/.+)$;
 		fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
1. We use native HTML lazy loading of images, to reduce the requests the initial page load
2. We switch to `thumb.php` so expensive resizing operations will not be performed in the initial HTML generation

HINT: This change may require an additional change in Extension:NSFileRepo. URL to be announced.

Depends-On: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/NSFileRepo/+/1277432
Depends-On: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/NSFileRepo/+/1277451
Depends-On: https://gitlab.hallowelt.com/BlueSpice/mediawiki/-/merge_requests/341
Depends-On: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/PDFCreator/+/1277450

ERM47579