### PR TITLE
Fix missing php module exif

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apk add \
 	php$VERSION-cli \
 	php$VERSION-ctype \
 	php$VERSION-curl \
+	php$VERSION-exif \
 	php$VERSION-fileinfo \
 	php$VERSION-fpm \
 	php$VERSION-gd \
@@ -67,6 +68,7 @@ RUN apk add \
 	php$VERSION-mbstring \
 	php$VERSION-mysqli \
 	php$VERSION-opcache \
+	php$VERSION-pcntl \
 	php$VERSION-pdo \
 	php$VERSION-pdo_mysql \
 	php$VERSION-pdo_pgsql \


### PR DESCRIPTION
so that method exif_read_data() can be called

Optionally add php module pcntl for
certain mediawiki maintenance scripts

ERM48018

[5.1.x]