### PR TITLE
set defaultvalues for FARM_DEFAULT_INSTANCE and WIKI_ARTICLE_PATH 

### DIFF
--- a/root-fs/app/bin/start-web
+++ b/root-fs/app/bin/start-web
@@ -23,10 +23,10 @@ case "${WIKI_LOG_LEVEL}" in
 esac
 
 substitutePlaceholders /app/conf/90-bluespice-overrides.ini
-if [[ ${FARM_DEFAULT_INSTANCE} ]]; then
+if [[ -n "${FARM_DEFAULT_INSTANCE:-}" ]]; then
 export WIKI_RETURN_PATH=${FARM_DEFAULT_INSTANCE}
 else
-export WIKI_RETURN_PATH=${WIKI_ARTICLE_PATH}
+  export WIKI_RETURN_PATH="${WIKI_ARTICLE_PATH:-}"
 fi
 substitutePlaceholders /app/conf/nginx_bluespice
 


### PR DESCRIPTION
set defaultvalues for FARM_DEFAULT_INSTANCE and WIKI_ARTICLE_PATH -> if these values are not set, the startup of web container breaks 