### PR TITLE
Remove installer log

### DIFF
--- a/root-fs/app/bin/run-installation.d/020-install-database
+++ b/root-fs/app/bin/run-installation.d/020-install-database
@@ -36,8 +36,7 @@ php $appDir/maintenance/install.php \
 	--lang=$lang \
 	--scriptpath=/w \
 	"$name" \
-	"$adminUserName" \
-	| tee -a /data/bluespice/logs/install-$timestamp.log
+	"$adminUserName"
 
 # We don't need the default LocalSettings.php file, as we have one hardwired in this container
 if [ -f $appDir/LocalSettings.php ]; then


### PR DESCRIPTION
We want to get rid of the `/data/` dir. As `wiki-installer` is already a separate service in the `bluespice-deploy` stack, it is sufficient that install log is being written to `stdout`.