### PR TITLE
5.2.x-cherry-pick: Allow to use new "HttpSAMLClient" in Extension:SimpleSAMLphp (#175)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,9 +110,10 @@ RUN addgroup -g $GID $GROUPNAME \
 COPY --chown=$USER:$GROUPNAME --from=builder /build/bluespice /app/bluespice/w
 COPY --chown=$USER:$GROUPNAME --from=builder /build/simplesamlphp /app/simplesamlphp
 RUN if [ -f /app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php ]; then \
-		cp -rp \
-			/app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php \
-			/app/simplesamlphp/public/api/session.php; \
+		mkdir -p /app/simplesamlphp/public/api && \
+		cp /app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php \
+			/app/simplesamlphp/public/api/session.php && \
+		chown -R $USER:$GROUPNAME /app/simplesamlphp/public/api; \
 	fi
 COPY --chown=$USER:$GROUPNAME --chmod=755 ./root-fs/app/bin /app/bin
 COPY --chown=$USER:$GROUPNAME --chmod=666 ./root-fs/app/bin/config /app/bin/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,9 @@
-FROM composer:2 AS workaround-erm-45965
-# Build SimpleSAMLphp from source, bypassing the original way of loading
-ENV SIMPLESAMLPHP_VERSION=2.3.11
-WORKDIR /build
-RUN git clone --depth 1 https://github.com/simplesamlphp/simplesamlphp.git -b v${SIMPLESAMLPHP_VERSION} /build/simplesamlphp && \
-	cd /build/simplesamlphp && \
-	composer require psr/http-message:^1.1 psr/container:^1.1 symfony/expression-language:^6.0 \
-		twig/twig:^3.26 twig/intl-extra:^3.26 symfony/twig-bridge:^6.4 \
-		symfony/cache:^6.4.40 symfony/routing:^6.4.40 symfony/yaml:^6.4.40 \
-		--no-cache --update-no-dev --prefer-dist --optimize-autoloader
-# The specific versions are taken from composer.json of MediaWiki REL1_43
-# To force psr/log:1.1.4, we remove simplesamlphp-test-framework (require-dev only)
-
 FROM alpine:3 AS builder
 
 # We use SimpleSAMLphp SLIM version to reduce the image size
-ENV SIMPLESAMLPHP_VERSION=2.4.4
+ENV SIMPLESAMLPHP_VERSION=2.5.2
 ENV SIMPLESAMLPHP_URL=https://github.com/simplesamlphp/simplesamlphp/releases/download/v${SIMPLESAMLPHP_VERSION}/simplesamlphp-${SIMPLESAMLPHP_VERSION}-slim.tar.gz
-ENV SIMPLESAMLPHP_SHA256=1c351342293d218447b27df9a03d2da7561d3831303524c173e8974b3168a57e
+ENV SIMPLESAMLPHP_SHA256=6bf7945e8981db9815e20af2bb17db8e44d265f0b1646bfa51e6dd755fef1ea6
 
 # HINT: This version is valid for 5.1 and 5.2; Later versions don't use this tool anymore. For the sake of reproducable builds, we hardcode the version here and adapt manually on demand
 ENV MATHOIDREMOTE_URL=https://raw.githubusercontent.com/hallowelt/docker-bluespice-formula/80786798646fe1bb105db2228a07c86f546d9f56/_client/mathoid-remote
@@ -121,9 +108,12 @@ RUN addgroup -g $GID $GROUPNAME \
 	&& chown $USER:$GROUPNAME /app/bluespice/ \
 	&& chmod -R 777 /var/log
 COPY --chown=$USER:$GROUPNAME --from=builder /build/bluespice /app/bluespice/w
-#COPY --chown=$USER:$GROUPNAME --from=builder /build/simplesamlphp /app/simplesamlphp
-# original load mechanism replaced by the following workaround:
-COPY --chown=$USER:$GROUPNAME --from=workaround-erm-45965 /build/simplesamlphp /app/simplesamlphp
+COPY --chown=$USER:$GROUPNAME --from=builder /build/simplesamlphp /app/simplesamlphp
+RUN if [ -f /app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php ]; then \
+		cp -rp \
+			/app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php \
+			/app/simplesamlphp/public/api/session.php; \
+	fi
 COPY --chown=$USER:$GROUPNAME --chmod=755 ./root-fs/app/bin /app/bin
 COPY --chown=$USER:$GROUPNAME --chmod=666 ./root-fs/app/bin/config /app/bin/config
 COPY --chown=$USER:$GROUPNAME ./root-fs/app/conf /app/conf

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ docker build \
 | `FORMULA_PORT`               | `10044`        | Port of a `bluespice/formula` compatible service     | Yes      |
 | `FORMULA_PROTOCOL`           | `http`         | Protocol of a `bluespice/formula` compatible service | Yes      |
 | `INTERNAL_CHAT_WIKI_ACCESS_TOKEN` | `null` | Access token `bluespice/chat` | No       |
+| `INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN`| `null`         | Token for SAML session API endpoint. Auto-generated during installation | No      |
 | `INTERNAL_WIKI_SECRETKEY`    | `null`         | Secret key for the wiki                              | No       |
 | `INTERNAL_WIKI_UPGRADEKEY`   | `null`         | Upgrade key for the wiki                             | No       |
 | `JOBQUEUE_HOST`              | `jobqueue`     | Hostname of a `bluespice/jobqueue` compatible service| Yes      |
@@ -63,6 +64,8 @@ docker build \
 | `PDF_HOST`                   | `pdf`          | Hostname of a `bluespice/pdf` compatible service     | Yes      |
 | `PDF_PORT`                   | `8080`         | Port of a `bluespice/pdf` compatible service         | Yes      |
 | `PDF_PROTOCOL`               | `http`         | Protocol of a `bluespice/pdf` compatible service     | Yes      |
+| `SAML_LOG_LEVEL`             | `$WIKI_LOG_LEVEL` | Log level for SAML operations.                    | Yes      |
+| `SAML_SESSION_API_ALLOWED`   | `null`       | Allowed CIDR range for SAML session API endpoint. Will default to internal Docker network CIDR | Yes      |
 | `SEARCH_HOST`                | `search`       | Hostname of a `bluespice/search` compatible service  | Yes      |
 | `SEARCH_PASS`                | ``             | Password of a `bluespice/search` compatible service  | Yes      |
 | `SEARCH_PORT`                | `9200`         | Port of a `bluespice/search` compatible service      | Yes      |

--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Calculate CIDR range for internal docker virtual netowrk. Only services in this range are allowed to access the SAML session check endpoint.
+local localCIDR=$(ip -o -f inet addr show eth0 | awk '{print $4}')
 
 cat <<'EOF' >> /app/.env
 # Antivirus service defaults
@@ -45,6 +47,10 @@ export FORMULA_PROTOCOL=${FORMULA_PROTOCOL:-http}
 export PDF_HOST=${PDF_HOST:-pdf}
 export PDF_PORT=${PDF_PORT:-8080}
 export PDF_PROTOCOL=${PDF_PROTOCOL:-http}
+
+# SimpleSAMLphp Service Provider defaults
+export SAML_SESSION_API_ALLOWED=${SAML_SESSION_API_ALLOWED:-$localCIDR}
+export INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN=${INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN:-}
 
 # Search service defaults
 export SEARCH_HOST=${SEARCH_HOST:-search}
@@ -100,6 +106,9 @@ export WIRE_PROTOCOL=${WIRE_PROTOCOL:-http}
 export DIAGRAM_HOST=${DIAGRAM_HOST:-$WIKI_HOST}
 export DIAGRAM_PORT=${DIAGRAM_PORT:-$WIKI_PORT}
 export DIAGRAM_PROTOCOL=${DIAGRAM_PROTOCOL:-$WIKI_PROTOCOL}
+
+# SAML_LOG_LEVEL - depends on WIKI_LOG_LEVEL
+export SAML_LOG_LEVEL=${SAML_LOG_LEVEL:-$WIKI_LOG_LEVEL}
 
 # Path adjustments
 export PATH=$PATH:/app/bin

--- a/root-fs/app/conf/LocalSettings.php
+++ b/root-fs/app/conf/LocalSettings.php
@@ -156,8 +156,14 @@ $GLOBALS['wgMathoidCli'] = [
 
 $GLOBALS['bsgInstanceStatusCheckAllowedIP'] = trim( getenv( 'WIKI_STATUSCHECK_ALLOWED' ) );
 
-
-$GLOBALS['wgSimpleSAMLphp_InstallDir'] = '/app/simplesamlphp';
+$GLOBALS['wgSimpleSAMLphp_SAMLClient'] = 'http-client';
+$GLOBALS['wgSimpleSAMLphp_HTTPClientConfig'] = [
+	'baseUrl' => 'http://localhost:9090/_sp/',
+	// Keep aligned with `root-fs/app/simplesamlphp/config/config.php`
+	'sessionIdCookieName' => getenv('DB_NAME') . ( getenv('DB_PREFIX') ) . 'SAMLSessionID',
+	'authTokenCookieName' => getenv('DB_NAME') . ( getenv('DB_PREFIX') ) . 'SAMLAuthToken',
+	'sessionAPItoken' => getenv( 'INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN' ) ?: ''
+];
 
 if ( getenv( 'DEV_WIKI_DEBUG' ) ) {
 	$GLOBALS['wgShowExceptionDetails'] = true;

--- a/root-fs/app/simplesamlphp/config/config.php
+++ b/root-fs/app/simplesamlphp/config/config.php
@@ -5,8 +5,25 @@ include (__DIR__ . '/config.php.dist');
 $serverUrl = bsAssembleURL( 'WIKI_PROTOCOL', 'WIKI_HOST', 'WIKI_PORT' );
 $baseUrl = $GLOBALS['wgServer'] = $serverUrl . rtrim(getenv('WIKI_BASE_PATH') ?: '', '/');
 
-// TODO calculate from environment variable
-$loglevel = SimpleSAML\Logger::WARNING;
+$loglevel = strtolower( trim( getenv( 'SAML_LOG_LEVEL' ) ?? 'error' ) );
+switch ( $loglevel ) {
+	case 'debug':
+		$loglevel = SimpleSAML\Logger::DEBUG;
+		break;
+	case 'info':
+		$loglevel = SimpleSAML\Logger::INFO;
+		break;
+	case 'notice':
+		$loglevel = SimpleSAML\Logger::NOTICE;
+		break;
+	case 'warning':
+		$loglevel = SimpleSAML\Logger::WARNING;
+		break;
+	case 'error':
+	default:
+		// Yes, it's `ERR`, not `ERROR`
+		$loglevel = SimpleSAML\Logger::ERR;
+}
 
 $customConfig = [
     'baseurlpath' => $baseUrl . '/_sp/',
@@ -73,6 +90,9 @@ $customConfig = [
 	'store.sql.username' => getenv('DB_USER'),
 	'store.sql.password' => getenv('DB_PASS'),
 	'store.sql.prefix' => ( getenv('DB_PREFIX') ) . 'SimpleSAMLphp_',
+
+	'mediawiki.sessionapi.token' => getenv( 'INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN' ) ?: '',
+	'mediawiki.sessionapi.allowedcallers' => getenv( 'SAML_SESSION_API_ALLOWED' ) ?: '',
 ];
 
 $config = $customConfig + $config;


### PR DESCRIPTION
* Allow to use new "HttpSAMLClient" in Extension:SimpleSAMLphp

Requires https://gerrit.wikimedia.org/r/c/mediawiki/extensions/SimpleSAMLphp/+/1307737

ERM46229
[5.1.x]

* Add proper log level

* Add / set new ENV vars

* Adjust Extension:SimpleSAMLphp config

* Cleanup

---------