### PR TITLE
Support openshift arbitrary uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,12 +96,12 @@ ENV UID=1002
 ARG USER
 ENV USER=bluespice
 ENV PATH="/app/bin:${PATH}"
-ARG GID
-ENV GID=$UID
-ARG GROUPNAME
-ENV GROUPNAME=$USER
+ARG GID=0
+ENV GID=$GID
+ARG GROUPNAME=root
+ENV GROUPNAME=$GROUPNAME
 
-RUN addgroup -g $GID $GROUPNAME \
+RUN grep -q "^${GROUPNAME}:" /etc/group || addgroup -g ${GID} ${GROUPNAME} \
 	&& adduser -u $UID -G $GROUPNAME --shell /bin/bash --disabled-password --gecos "" $USER \
 	&& addgroup $USER nginx \
 	&& mkdir -p /app/bluespice \
@@ -137,11 +137,13 @@ RUN ln -sf /usr/sbin/php-fpm$VERSION /usr/bin/php-fpm \
 	&& ln -s /app/conf/90-bluespice-overrides.ini /etc/php$VERSION/conf.d/90-bluespice-overrides.ini \
 	&& ln -s /app/conf/nginx_bluespice /etc/nginx/sites-enabled/default \
 	&& chown -R $USER:$GROUPNAME /var/run/php \
+	&& chmod -R g=u /var/run/php \
 	&& mkdir -p /etc/clamav/ \
 	&& ln -s /app/bin/config/clamd.conf /etc/clamav/clamd.conf \
 	&& touch /app/.env \
 	&& chown $USER:$GROUPNAME /app/.env \
 	&& chmod 660 /app/.env \
+	&& chmod -R g=u /app \
 	&& sed -i '1isource /app/.env' /etc/bash/bashrc
 
 ARG EDITION # Intentionally left uninitialized


### PR DESCRIPTION
### To support running on Red Hat OpenShift Security Context Constraints

**What it does:**

Each namespace gets a UID range.
Pods must run with a UID from that range.
OpenShift assigns the UID automatically, resulting in an arbitrary user ID instead of the one defined in the image. The user is in GID 0.
This UID changes between restarts.

See:
https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html/creating_images/creating-images-guidelines#openshift-specific-guidelines

**Test:**
One can test this, for example, in a Docker Compose file:
`user: "10398902:0"   # random high UID + group 0 (root group)`

**Note:**
Because prepare does not create the folders with the root group, setting `user` in `docker-compose.yaml ` for containers with volumes will cause errors in a normal docker installation. One has to manually sett the folder permissions.

In an OpenShift environment, the permissions for volumes should be set automatically to the correct ones (g=u).


**This should not have any real affects on onpremise systems**.