### PR TITLE
Assign same permission for group and user for copied files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ADD ${BLUESPICE_URL}#${BLUESPICE_VERSION} /build/bluespice
 
 RUN mkdir -p /build/simplesamlphp && \
 	tar -xzf /build/simplesamlphp.tar.gz -C /build/simplesamlphp --strip-components=1
-RUN rm -rf /build/.git
+RUN chmod -R g=u /build
 
 FROM alpine:3 AS base
 ENV LANG=C.UTF-8
@@ -104,8 +104,9 @@ ENV GROUPNAME=$GROUPNAME
 RUN grep -q "^${GROUPNAME}:" /etc/group || addgroup -g ${GID} ${GROUPNAME} \
 	&& adduser -u $UID -G $GROUPNAME --shell /bin/bash --disabled-password --gecos "" $USER \
 	&& addgroup $USER nginx \
-	&& mkdir -p /app/bluespice \
-	&& chown $USER:$GROUPNAME /app/bluespice/ \
+	&& mkdir -p /app/bin /app/bluespice /app/conf /app/cron /app/simplesamlphp \
+	&& chown -R $USER:$GROUPNAME /app \
+	&& chmod -R g=u /app \
 	&& chmod -R 777 /var/log
 COPY --chown=$USER:$GROUPNAME --from=builder /build/bluespice /app/bluespice/w
 COPY --chown=$USER:$GROUPNAME --from=builder /build/simplesamlphp /app/simplesamlphp
@@ -113,16 +114,17 @@ RUN if [ -f /app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/
 		mkdir -p /app/simplesamlphp/public/api && \
 		cp /app/bluespice/w/extensions/SimpleSAMLphp/_simplesamlphp/public/api/session.php \
 			/app/simplesamlphp/public/api/session.php && \
-		chown -R $USER:$GROUPNAME /app/simplesamlphp/public/api; \
+		chown -R $USER:$GROUPNAME /app/simplesamlphp/public && \
+		chmod -R g=u /app/simplesamlphp/public; \
 	fi
-COPY --chown=$USER:$GROUPNAME --chmod=755 ./root-fs/app/bin /app/bin
+COPY --chown=$USER:$GROUPNAME --chmod=775 ./root-fs/app/bin /app/bin
 COPY --chown=$USER:$GROUPNAME --chmod=666 ./root-fs/app/bin/config /app/bin/config
 COPY --chown=$USER:$GROUPNAME ./root-fs/app/conf /app/conf
 COPY --chown=$USER:$GROUPNAME ./root-fs/app/simplesamlphp/ /app/simplesamlphp
 COPY --chown=$USER:$GROUPNAME ./root-fs/app/cron /app/cron
-COPY --chown=$USER:$GROUPNAME --from=builder --chmod=755 /build/mathoid-remote /app/bin
-COPY --chown=$USER:$GROUPNAME --from=builder --chmod=755 /build/mediawiki-adm /app/bin
-COPY --chown=$USER:$GROUPNAME --from=builder --chmod=755 /build/parallel-runjobs-service /app/bin
+COPY --chown=$USER:$GROUPNAME --from=builder --chmod=775 /build/mathoid-remote /app/bin
+COPY --chown=$USER:$GROUPNAME --from=builder --chmod=775 /build/mediawiki-adm /app/bin
+COPY --chown=$USER:$GROUPNAME --from=builder --chmod=775 /build/parallel-runjobs-service /app/bin
 COPY ./root-fs/etc/php/8.x/fpm/php-fpm.conf /etc/php$VERSION
 COPY ./root-fs/etc/php/8.x/fpm/pool.d/www.conf /etc/php$VERSION/php-fpm.d/
 COPY ./root-fs/etc/nginx/nginx.conf /etc/nginx/nginx.conf
@@ -143,7 +145,7 @@ RUN ln -sf /usr/sbin/php-fpm$VERSION /usr/bin/php-fpm \
 	&& touch /app/.env \
 	&& chown $USER:$GROUPNAME /app/.env \
 	&& chmod 660 /app/.env \
-	&& chmod -R g=u /app \
+	&& echo "umask 0002" >> /etc/bash/bashrc \
 	&& sed -i '1isource /app/.env' /etc/bash/bashrc
 
 ARG EDITION # Intentionally left uninitialized

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,7 +104,7 @@ ENV GROUPNAME=$GROUPNAME
 RUN grep -q "^${GROUPNAME}:" /etc/group || addgroup -g ${GID} ${GROUPNAME} \
 	&& adduser -u $UID -G $GROUPNAME --shell /bin/bash --disabled-password --gecos "" $USER \
 	&& addgroup $USER nginx \
-	&& mkdir -p /app/bin /app/bluespice /app/conf /app/cron /app/simplesamlphp \
+	&& mkdir -p /app/bin /app/bluespice/w /app/conf /app/cron /app/simplesamlphp \
 	&& chown -R $USER:$GROUPNAME /app \
 	&& chmod -R g=u /app \
 	&& chmod -R 777 /var/log
@@ -139,7 +139,7 @@ RUN ln -sf /usr/sbin/php-fpm$VERSION /usr/bin/php-fpm \
 	&& ln -s /app/conf/90-bluespice-overrides.ini /etc/php$VERSION/conf.d/90-bluespice-overrides.ini \
 	&& ln -s /app/conf/nginx_bluespice /etc/nginx/sites-enabled/default \
 	&& chown -R $USER:$GROUPNAME /var/run/php \
-	&& chmod -R g=u /var/run/php \
+	&& chmod -R g=u /var/run/php /app/conf /app/cron /app/simplesamlphp/config /app/simplesamlphp/metadata \
 	&& mkdir -p /etc/clamav/ \
 	&& ln -s /app/bin/config/clamd.conf /etc/clamav/clamd.conf \
 	&& touch /app/.env \


### PR DESCRIPTION
Also ensure such correspondence for newly created files or dirs in an interactive shell.

This is a follow-up change of hallowelt/docker-bluespice-wik#199 and hallowelt/docker-bluespice-wik#200

Bulky operations like a `chmod -R g=u` on bluespice/simplesamlphp codebases can be resource consuming, both in build time and in layer size. As this operation cannot be avoided, we use multi-stage build to hide it from being a layer in the exported image. 

ERM48055

[5.1.x]