### PR TITLE
Remove the failing auto detect of SAML allowed CIDR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker build \
 | `PDF_PORT`                   | `8080`         | Port of a `bluespice/pdf` compatible service         | Yes      |
 | `PDF_PROTOCOL`               | `http`         | Protocol of a `bluespice/pdf` compatible service     | Yes      |
 | `SAML_LOG_LEVEL`             | `$WIKI_LOG_LEVEL` | Log level for SAML operations.                    | Yes      |
-| `SAML_SESSION_API_ALLOWED`   | `null`       | Allowed CIDR range for SAML session API endpoint. Will default to internal Docker network CIDR | Yes      |
+| `SAML_SESSION_API_ALLOWED`   | `''`           | Additional allowed CIDR range for SAML session API endpoint beside `127.0.0.1/32` | Yes      |
 | `SEARCH_HOST`                | `search`       | Hostname of a `bluespice/search` compatible service  | Yes      |
 | `SEARCH_PASS`                | ``             | Password of a `bluespice/search` compatible service  | Yes      |
 | `SEARCH_PORT`                | `9200`         | Port of a `bluespice/search` compatible service      | Yes      |

--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Calculate CIDR range for internal docker virtual netowrk. Only services in this range are allowed to access the SAML session check endpoint.
-local localCIDR=$(ip -o -f inet addr show eth0 | awk '{print $4}')
-
 cat <<'EOF' >> /app/.env
 # Antivirus service defaults
 export AV_HOST=${AV_HOST:--}
@@ -44,7 +41,7 @@ export PDF_PORT=${PDF_PORT:-8080}
 export PDF_PROTOCOL=${PDF_PROTOCOL:-http}
 
 # SimpleSAMLphp Service Provider defaults
-export SAML_SESSION_API_ALLOWED=${SAML_SESSION_API_ALLOWED:-$localCIDR}
+export SAML_SESSION_API_ALLOWED=${SAML_SESSION_API_ALLOWED:-}
 export INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN=${INTERNAL_SIMPLESAMLPHP_SESSION_API_TOKEN:-}
 
 # Search service defaults


### PR DESCRIPTION
as `local` can only be used inside a function, the original implementation would cause an error and would block container from getting up in certain strict setup. 

In fact, this mechanism never worked; https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/extensions/SimpleSAMLphp/+/refs/tags/7.1.0/_simplesamlphp/public/api/session.php#134 allowed 127.0.0.1(/32), which is why past tests were successful.

With this hard coded default, we can safely leave this CIDR range blank. 

[5.1.x]