### PR TITLE
Add `maintenance-shell` mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apk add \
 	procps \
 	python3 \
 	rsvg-convert \
+	ttyd \
 	tzdata \
 	vim \
 	vips-tools \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ docker build \
 	-t bluespice/wiki:latest .
 ```
 
+## Container modes
+
+The mode of a container is selected by the command it is started with:
+
+| Command                    | Mode                | Description                                                        |
+|----------------------------|---------------------|--------------------------------------------------------------------|
+| `start-web`                | `web`               | Serves the wiki (`nginx` + `php-fpm`) on port `9090`               |
+| `start-task`               | `task`              | Runs `runJobs` and/or the `ProcessRunner` (see `--runAll`)         |
+| `start-maintenance-shell`  | `maintenance-shell` | Serves a web terminal with a shell inside the container            |
+
+### `maintenance-shell` mode
+
+This mode starts [`ttyd`](https://github.com/tsl0922/ttyd), which exposes an interactive `bash` session in the browser. The shell runs as the container user, with the same environment as `docker exec`, so all maintenance commands (`run-maintenance`, `run-updates`, `rebuild-searchindex`, ...) are available. It is meant for environments where no direct `docker exec`/`kubectl exec` access is available.
+
+The terminal is protected by HTTP basic authentication. `MAINTENANCE_SHELL_PASS` is mandatory - the container refuses to start without it. It can also be provided as a Docker secret in `/run/secrets/MAINTENANCE_SHELL_PASS`.
+
+```yaml
+  wiki-maintenance:
+    image: bluespice/wiki:latest
+    command: start-maintenance-shell
+    environment:
+      MAINTENANCE_SHELL_USER: maintenance
+      MAINTENANCE_SHELL_PASS: <a-strong-password>
+    volumes:
+      - wiki-data:/data
+```
+
+By default the shell listens on port `9090`, the same port the `web` mode uses, so an existing port mapping or reverse proxy configuration can be reused when the container is started in this mode instead of `web`. Use `MAINTENANCE_SHELL_PORT` if both modes need to run side by side.
+
+Since basic authentication and the terminal traffic are not encrypted by the container itself, only expose this mode through a TLS terminating reverse proxy.
+
 ## ENV vars
 
 | Variable                     | Default Value  | Description                                          | Optional |
@@ -70,6 +101,10 @@ docker build \
 | `INTERNAL_WIRE_API_KEY`      | `null`         | API key for `bluespice/wire` service                     | No, if `WIRE_HOST` is set |
 | `JOBQUEUE_HOST`              | `jobqueue`     | Hostname of a `bluespice/jobqueue` compatible service| Yes      |
 | `JOBQUEUE_PORT`              | `6379`         | Port of a `bluespice/jobqueue` compatible service          | Yes      |
+| `MAINTENANCE_SHELL_CHECK_ORIGIN` | `1`        | Reject websocket connections from foreign origins in `maintenance-shell` mode *****) | Yes      |
+| `MAINTENANCE_SHELL_PASS`     | `null`         | Password for the `maintenance-shell` mode            | No, in `maintenance-shell` mode |
+| `MAINTENANCE_SHELL_PORT`     | `9090`         | Port the `maintenance-shell` mode listens on         | Yes      |
+| `MAINTENANCE_SHELL_USER`     | `maintenance`  | User name for the `maintenance-shell` mode           | Yes      |
 | `MAX_UPLOAD_SIZE`            | `1024m`        | Max upload size for single file (Allowed: m or g)    | Yes      |
 | `PDF_HOST`                   | `pdf`          | Hostname of a `bluespice/pdf` compatible service     | Yes      |
 | `PDF_PORT`                   | `8080`         | Port of a `bluespice/pdf` compatible service         | Yes      |
@@ -119,6 +154,8 @@ docker build \
 ***) For a farm with non-default `WIKI_ARTICLE_PATH`, set `FAMR_DEFAULT_INSTANCE` as well, e.g `w` the root farm instance.
 
 ****) Functions requiring `bluespice/chat` can be disabled by setting `-` as `CHAT_HOST`.
+
+*****) Set to `0` if the reverse proxy in front of the container does not pass through the original `Host` header.
 
 ## Directories and Volumes
 
@@ -203,4 +240,4 @@ If `WIKI_FARM_USE_SHARED_DB` is set to `1`, the `FARM` edition will store the wi
 # Liveness and readiness probes
 The container exposes the following commands for liveness and readiness probes:
 - `probe-liveness` - Exists with 0 if the application is healthy
-- `probe-readiness <type>` - Value of `<type>` can be `web` or `task`. Exists with 0 if the application is ready
+- `probe-readiness <type>` - Value of `<type>` can be `web`, `task` or `maintenance-shell`. Exists with 0 if the application is ready

--- a/root-fs/app/bin/init-envs
+++ b/root-fs/app/bin/init-envs
@@ -40,6 +40,12 @@ export FORMULA_HOST=${FORMULA_HOST:-formula}
 export FORMULA_PORT=${FORMULA_PORT:-10044}
 export FORMULA_PROTOCOL=${FORMULA_PROTOCOL:-http}
 
+# Maintenance shell defaults
+# MAINTENANCE_SHELL_PASS is mandatory for the `start-maintenance-shell` mode and has no default value
+export MAINTENANCE_SHELL_CHECK_ORIGIN=${MAINTENANCE_SHELL_CHECK_ORIGIN:-1}
+export MAINTENANCE_SHELL_PORT=${MAINTENANCE_SHELL_PORT:-9090}
+export MAINTENANCE_SHELL_USER=${MAINTENANCE_SHELL_USER:-maintenance}
+
 # PDF service defaults
 export PDF_HOST=${PDF_HOST:-pdf}
 export PDF_PORT=${PDF_PORT:-8080}

--- a/root-fs/app/bin/probe-readiness
+++ b/root-fs/app/bin/probe-readiness
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Must be run like this, where <type> can be "web" or "task"
+# Must be run like this, where <type> can be "web", "task" or "maintenance-shell"
 # docker exec -it <container_name> probe-readiness <type>
 
 type=$1
@@ -14,6 +14,13 @@ if [[ $type == "web" ]]; then
 	fi
 fi
 if [[ $type == "task" ]]; then
+	if grep -q "ready" /tmp/state; then
+		exit 0
+	else
+		exit 1
+	fi
+fi
+if [[ $type == "maintenance-shell" ]]; then
 	if grep -q "ready" /tmp/state; then
 		exit 0
 	else

--- a/root-fs/app/bin/start-maintenance-shell
+++ b/root-fs/app/bin/start-maintenance-shell
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+MAINTENANCE_SHELL_PORT="${MAINTENANCE_SHELL_PORT:-9090}"
+MAINTENANCE_SHELL_USER="${MAINTENANCE_SHELL_USER:-maintenance}"
+
+echo ""
+echo "#############################################"
+echo "🖥️ Starting MaintenanceShell"
+
+if [[ -z "${MAINTENANCE_SHELL_PASS}" ]]; then
+	echo "❌ MAINTENANCE_SHELL_PASS is not set. Refusing to start an unauthenticated shell."
+	echo "   Provide it as an environment variable or as /run/secrets/MAINTENANCE_SHELL_PASS."
+	exit 1
+fi
+
+ttydArgs=(
+	--port "${MAINTENANCE_SHELL_PORT}"
+	--writable
+	--credential "${MAINTENANCE_SHELL_USER}:${MAINTENANCE_SHELL_PASS}"
+	--terminal-type xterm-256color
+	--client-option "titleFixed=BlueSpice MaintenanceShell"
+)
+
+# Reject websocket connections from foreign origins, unless explicitly disabled.
+# May need to be disabled if the reverse proxy in front does not pass through the original `Host` header.
+if [[ "${MAINTENANCE_SHELL_CHECK_ORIGIN:-1}" == "1" ]]; then
+	ttydArgs+=( --check-origin )
+fi
+
+# Align with the path the web frontend is served from, in case a reverse proxy mounts the container on a subpath
+if [[ "${WIKI_BASE_PATH:-/}" != "/" ]]; then
+	ttydArgs+=( --base-path "${WIKI_BASE_PATH%/}" )
+fi
+
+echo "" > /tmp/healthcheck
+echo "ttyd" >> /tmp/healthcheck
+
+echo "🔐 Listening on port ${MAINTENANCE_SHELL_PORT}, login as '${MAINTENANCE_SHELL_USER}'"
+
+echo "ready" > /tmp/state
+
+exec ttyd "${ttydArgs[@]}" bash


### PR DESCRIPTION
Can be used in environments that have limited access to the host environment.

Use with caution.

[ai generated]
[5.1.x]